### PR TITLE
Update Authentication Flow and Translations

### DIFF
--- a/assets/translations/ar.json
+++ b/assets/translations/ar.json
@@ -17,7 +17,7 @@
   "alreadyHaveAccount": "هل لديك حساب بالفعل؟",
   "invalidEmail": "عنوان البريد الإلكتروني غير صالح.",
   "userNotFound": "لا يوجد مستخدم مرتبط بهذا البريد الإلكتروني.",
-  "wrongPassword": "كلمة المرور غير صحيحة.",
+  "invalidCredentials": "البريد الإلكتروني او كلمة المرور غير صحيحة.",
   "emailAlreadyInUse": "عنوان البريد الإلكتروني مستخدم بالفعل.",
   "authenticationFailed": "فشل في عملية المصادقة. يرجى المحاولة مرة أخرى.",
   "permissionDenied": "ليس لديك الإذن للوصول إلى هذا المورد.",
@@ -53,5 +53,6 @@
   "fieldsRequired" : "هذا الحقل مطلوب",
   "mustBeAtLeast6Chars": "يجب أن يكون على الأقل 6 حروف.",
   "invalidEmailInput" : "البريد الإلكتروني غير صالح.",
-  "likes": "اعجابات"
+  "likes": "اعجابات",
+  "LoginTo" : "سجل دخولك الى "
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -23,7 +23,7 @@
   "sloganMessage": "Connect. Collaborate. Code.",
   "unexpectedError": "An unexpected error occurred. Please try again later.",
   "userNotFound": "No user found for that email.",
-  "wrongPassword": "The password is incorrect.",
+  "invalidCredentials": "Email or password is invalid.",
   "welcomeMessage": "Welcome to TechTide!",
   "getStarted": "Get Started",
   "signup": "Sign Up",
@@ -53,5 +53,6 @@
   "fieldsRequired" : "This field is required.",
   "mustBeAtLeast6Chars": "Must be at least 6 characters long.",
   "invalidEmailInput" : "Please enter a valid email.",
-  "likes": "Likes"
+  "likes": "Likes",
+  "loginTo" : "Login To "
 }

--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -1,6 +1,12 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tech_tide/core/utils/app_preferences.dart';
+import 'package:tech_tide/features/auth/data/data_source/auth_data_source.dart';
+import 'package:tech_tide/features/auth/data/repo/auth_repo_impl.dart';
+import 'package:tech_tide/features/auth/domain/repo/auth_repository.dart';
+import 'package:tech_tide/features/auth/presentation/cubit/auth_cubit.dart';
 import 'package:tech_tide/features/home_layout/presentation/provider/layout_controller.dart';
 
 part 'di.main.dart';

--- a/lib/core/di/di.main.dart
+++ b/lib/core/di/di.main.dart
@@ -7,8 +7,29 @@ abstract class ServiceLocator {
 
   static Future init() async {
     final sharedPreferences = await SharedPreferences.getInstance();
-    _getIt.registerLazySingleton<AppPreferences>(
-        () => AppPreferences(sharedPreferences));
+    _getIt
+      ..registerLazySingleton<AppPreferences>(
+          () => AppPreferences(sharedPreferences))
+      ..registerLazySingleton<FirebaseAuth>(() => FirebaseAuth.instance)
+      ..registerLazySingleton<FirebaseFirestore>(
+          () => FirebaseFirestore.instance);
+  }
+
+  static initAuth() async {
+    if (!_getIt.isRegistered<AuthCubit>()) {
+      _getIt
+        ..registerLazySingleton<AuthDataSource>(
+            () => AuthDataSourceImpl(_getIt(), _getIt()))
+        ..registerLazySingleton<AuthRepository>(
+            () => AuthRepositoryImpl(_getIt()))
+        ..registerLazySingleton<AuthCubit>(() => AuthCubit(_getIt(), _getIt()));
+    }
+  }
+
+  static unRegisterAuth() {
+    _getIt.unregister<AuthDataSource>();
+    _getIt.unregister<AuthRepository>();
+    _getIt.unregister<AuthCubit>();
   }
 
   static Future initHome() async {

--- a/lib/core/network/error_handler.dart
+++ b/lib/core/network/error_handler.dart
@@ -22,8 +22,8 @@ abstract class ErrorHandler {
         return Failure(message: ErrorMessages.invalidEmail.translate);
       case 'user-not-found':
         return Failure(message: ErrorMessages.userNotFound.translate);
-      case 'wrong-password':
-        return Failure(message: ErrorMessages.wrongPassword.translate);
+      case 'invalid-credential':
+        return Failure(message: ErrorMessages.invalidCredentials.translate);
       case 'email-already-in-use':
         return Failure(message: ErrorMessages.emailAlreadyInUse.translate);
       default:

--- a/lib/core/network/error_messages.dart
+++ b/lib/core/network/error_messages.dart
@@ -2,7 +2,7 @@
 abstract class ErrorMessages {
   static const String invalidEmail = "invalidEmail";
   static const String userNotFound = "userNotFound";
-  static const String wrongPassword = "wrongPassword";
+  static const String invalidCredentials = "invalidCredentials";
   static const String emailAlreadyInUse = "emailAlreadyInUse";
   static const String authenticationFailed = "authenticationFailed";
   static const String permissionDenied = "permissionDenied";

--- a/lib/core/res/strings_manager.dart
+++ b/lib/core/res/strings_manager.dart
@@ -6,6 +6,7 @@ abstract class AppStrings {
   static const String onboardingSubTitle = 'onboardingSubTitle';
   static const String getStarted = 'getStarted';
   static const String createAccount = 'createAccount';
+  static const String loginTo = 'loginTo';
   static const String name = 'name';
   static const String email = 'email';
   static const String password = 'password';

--- a/lib/core/routes/routes_manager.dart
+++ b/lib/core/routes/routes_manager.dart
@@ -1,15 +1,18 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:tech_tide/core/di/di.dart';
 import 'package:tech_tide/core/widgets/slide_transition.dart';
+import 'package:tech_tide/features/auth/presentation/cubit/auth_cubit.dart';
+import 'package:tech_tide/features/auth/presentation/views/login_view.dart';
 import 'package:tech_tide/features/auth/presentation/views/signup_view.dart';
 import 'package:tech_tide/features/home_layout/presentation/provider/layout_controller.dart';
 import 'package:tech_tide/features/home_layout/presentation/views/home_layout.dart';
 import 'package:tech_tide/features/onboarding/views/onboarding_view.dart';
 import 'package:tech_tide/features/splash/presentation/splash_view.dart';
 
+import '../../features/event_details/presentation/views/event_details_view.dart';
 import '../../features/popular_topic/presentation/views/popular_topic_view.dart';
 import '../../features/post_details/presentation/views/post_details_view.dart';
-import '../../features/event_details/presentation/views/event_details_view.dart';
 
 part 'routes_manager.main.dart';

--- a/lib/core/routes/routes_manager.main.dart
+++ b/lib/core/routes/routes_manager.main.dart
@@ -4,6 +4,7 @@ abstract class Routes {
   static const String initialRoute = '/';
   static const String onboardingRoute = '/onboarding';
   static const String signUpRoute = '/sign-up';
+  static const String loginRoute = '/login';
   static const String homeRoute = '/home';
   static const String popularTopicsRoute = '/popular-topics';
   static const String postDetailsRoute = '/post-details';
@@ -35,9 +36,24 @@ abstract class RouteGenerator {
         },
       ),
       GoRoute(
-        path: Routes.signUpRoute,
+        path: Routes.loginRoute,
         builder: (context, state) {
-          return const SignupView();
+          ServiceLocator.initAuth();
+          return BlocProvider<AuthCubit>(
+            create: (context) => ServiceLocator.get(),
+            child: const LoginView(),
+          );
+        },
+      ),
+      GoRoute(
+        path: Routes.signUpRoute,
+        pageBuilder: (context, state) {
+          return CustomSlideTransition(
+            child: BlocProvider<AuthCubit>.value(
+              value: ServiceLocator.get(),
+              child: const SignupView(),
+            ),
+          );
         },
       ),
       GoRoute(

--- a/lib/core/utils/app_preferences.dart
+++ b/lib/core/utils/app_preferences.dart
@@ -5,6 +5,8 @@ import 'package:tech_tide/core/utils/local_manager.dart';
 
 const String _prefsKeyLanguage = "PREFS_KEY_LANG";
 
+const String _prefsKeyUserId = "PREFS_KEY_USER_ID";
+
 class AppPreferences {
   final SharedPreferences _sharedPreferences;
 
@@ -21,5 +23,13 @@ class AppPreferences {
 
   Future<void> setAppLanguage(LanguageType language) async {
     await _sharedPreferences.setString(_prefsKeyLanguage, language.value);
+  }
+
+  Future<void> setUserId(String userId) async {
+    await _sharedPreferences.setString(_prefsKeyUserId, userId);
+  }
+
+  String? getUserId() {
+    return _sharedPreferences.getString(_prefsKeyUserId);
   }
 }

--- a/lib/core/widgets/custom_snack_bar.dart
+++ b/lib/core/widgets/custom_snack_bar.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:tech_tide/core/res/color_manager.dart';
+import 'package:tech_tide/core/res/styles_manager.dart';
+
+abstract class CustomSnackBar {
+  static success(String message, BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: StylesManager.medium16,
+        ),
+        backgroundColor: ColorManager.primary,
+      ),
+    );
+  }
+
+  static error(String message, BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: StylesManager.medium16,
+        ),
+        backgroundColor: ColorManager.error,
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/views/auth_listener_widget.dart
+++ b/lib/features/auth/presentation/views/auth_listener_widget.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:tech_tide/core/routes/routes_manager.dart';
+import 'package:tech_tide/core/utils/extensions.dart';
+import 'package:tech_tide/core/widgets/custom_snack_bar.dart';
+import 'package:tech_tide/features/auth/presentation/cubit/auth_cubit.dart';
+
+class AuthListenerWidget extends StatelessWidget {
+  final Widget child;
+
+  const AuthListenerWidget({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthCubit, AuthState>(
+      listener: (context, state) {
+        if (state is AuthError) {
+          CustomSnackBar.error(state.message, context);
+        } else if (state is AuthSuccess) {
+          context.popAllThenPush(Routes.homeRoute);
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/features/auth/presentation/views/login_view.dart
+++ b/lib/features/auth/presentation/views/login_view.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:tech_tide/core/res/values_manager.dart';
 import 'package:tech_tide/features/auth/presentation/views/auth_listener_widget.dart';
 import 'package:tech_tide/features/auth/presentation/widgets/header_image_widget.dart';
-import 'package:tech_tide/features/auth/presentation/widgets/signup_view_body.dart';
+import 'package:tech_tide/features/auth/presentation/widgets/login_view_body.dart';
 
-class SignupView extends StatelessWidget {
-  const SignupView({super.key});
+class LoginView extends StatelessWidget {
+  const LoginView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +37,7 @@ class SignupView extends StatelessWidget {
                         start: AppPadding.p20,
                         end: AppPadding.p20,
                       ),
-                      child: SignupViewBody(),
+                      child: LoginViewBody(),
                     ),
                   ),
                 ),

--- a/lib/features/auth/presentation/widgets/auth_submit_button.dart
+++ b/lib/features/auth/presentation/widgets/auth_submit_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:tech_tide/core/widgets/custom_wide_button.dart';
+import 'package:tech_tide/features/auth/presentation/cubit/auth_cubit.dart';
+
+class AuthSubmitButton extends StatelessWidget {
+  const AuthSubmitButton({super.key, this.onPressed, required this.buttonText});
+  final Function()? onPressed;
+  final String buttonText;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AuthCubit, AuthState>(
+      builder: (context, state) {
+        if (state is AuthLoading) {
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+        return CustomWideButton(
+          buttonText: buttonText,
+          onPressed: onPressed,
+        );
+      },
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/dont_have_account_button.dart
+++ b/lib/features/auth/presentation/widgets/dont_have_account_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tech_tide/core/res/color_manager.dart';
+import 'package:tech_tide/core/res/strings_manager.dart';
+import 'package:tech_tide/core/res/styles_manager.dart';
+import 'package:tech_tide/core/routes/routes_manager.dart';
+import 'package:tech_tide/core/utils/extensions.dart';
+
+class DontHaveAccountButton extends StatelessWidget {
+  const DontHaveAccountButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          AppStrings.dontHaveAccount.translate,
+          style: StylesManager.medium14,
+        ),
+        TextButton(
+          onPressed: () {
+            context.push(Routes.signUpRoute);
+          },
+          child: Text(
+            AppStrings.signup.translate,
+            style: StylesManager.medium14.copyWith(color: ColorManager.primary),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/login_view_body.dart
+++ b/lib/features/auth/presentation/widgets/login_view_body.dart
@@ -5,29 +5,23 @@ import 'package:tech_tide/core/res/strings_manager.dart';
 import 'package:tech_tide/core/res/values_manager.dart';
 import 'package:tech_tide/core/utils/extensions.dart';
 import 'package:tech_tide/features/auth/presentation/cubit/auth_cubit.dart';
-import 'package:tech_tide/features/auth/presentation/widgets/already_have_account_button.dart';
 import 'package:tech_tide/features/auth/presentation/widgets/auth_submit_button.dart';
 import 'package:tech_tide/features/auth/presentation/widgets/auth_welcome_text.dart';
+import 'package:tech_tide/features/auth/presentation/widgets/dont_have_account_button.dart';
 import 'package:tech_tide/features/auth/presentation/widgets/labeled_textfield.dart';
 import 'package:tech_tide/features/auth/presentation/widgets/password_form_field.dart';
 
-class SignupViewBody extends StatefulWidget {
-  const SignupViewBody({super.key});
+class LoginViewBody extends StatefulWidget {
+  const LoginViewBody({super.key});
 
   @override
-  State<SignupViewBody> createState() => _SignupViewBodyState();
+  State<LoginViewBody> createState() => _LoginViewBodyState();
 }
 
-class _SignupViewBodyState extends State<SignupViewBody> {
-  final TextEditingController _nameController = TextEditingController();
-
+class _LoginViewBodyState extends State<LoginViewBody> {
   final TextEditingController _emailController = TextEditingController();
 
   final TextEditingController _passwordController = TextEditingController();
-
-  final TextEditingController _confirmPasswordController =
-      TextEditingController();
-
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   @override
@@ -38,19 +32,9 @@ class _SignupViewBodyState extends State<SignupViewBody> {
         child: Column(
           children: [
             AuthWelcomeText(
-              text: AppStrings.createAccount.translate,
+              text: AppStrings.loginTo.translate,
             ),
             const SizedBox(height: AppSize.s20),
-            LabeledTextField(
-              label: AppStrings.name.translate,
-              hintText: AppStrings.nameHint.translate,
-              controller: _nameController,
-              validator: ValidationBuilder()
-                  .minLength(6, AppStrings.mustBeAtLeast6Chars.translate)
-                  .required(AppStrings.fieldsRequired.translate)
-                  .build(),
-            ),
-            const SizedBox(height: AppSize.s16),
             LabeledTextField(
               label: AppStrings.email.translate,
               hintText: AppStrings.emailHint.translate,
@@ -70,42 +54,23 @@ class _SignupViewBodyState extends State<SignupViewBody> {
                   .minLength(6, AppStrings.mustBeAtLeast6Chars.translate)
                   .build(),
             ),
-            const SizedBox(height: AppSize.s16),
-            PasswordFormField(
-                label: AppStrings.confirmPassword.translate,
-                hintText: AppStrings.confirmPasswordHint.translate,
-                controller: _confirmPasswordController,
-                validator: ValidationBuilder(
-                        requiredMessage: AppStrings.fieldsRequired.translate)
-                    .add(_confirmPasswordValidator)
-                    .build()),
             const SizedBox(height: AppSize.s40),
             AuthSubmitButton(
-              buttonText: AppStrings.signup.translate,
+              buttonText: AppStrings.login.translate,
               onPressed: () {
                 if (_formKey.currentState?.validate() ?? false) {
-                  context.read<AuthCubit>().register(
+                  context.read<AuthCubit>().login(
                         email: _emailController.text.trim(),
-                        username: _nameController.text.trim(),
                         password: _passwordController.text,
                       );
                 }
               },
             ),
             const SizedBox(height: AppSize.s12),
-            const AlreadyHaveAccountButton(),
+            const DontHaveAccountButton(),
           ],
         ),
       ),
     );
-  }
-
-  StringValidationCallback get _confirmPasswordValidator {
-    return (value) {
-      if (value != _passwordController.text) {
-        return AppStrings.passwordDontMatch.translate;
-      }
-      return null;
-    };
   }
 }

--- a/lib/features/events/presentation/views/events_view.dart
+++ b/lib/features/events/presentation/views/events_view.dart
@@ -9,9 +9,9 @@ class EventsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: GradientAppBar(title: 'Events'),
+      appBar: const GradientAppBar(title: 'Events'),
       body: ListView(
-        children: [
+        children: const [
           EventCard(),
           EventCard(),
         ],

--- a/lib/features/onboarding/widgets/onboarding_view_bottom_sheet.dart
+++ b/lib/features/onboarding/widgets/onboarding_view_bottom_sheet.dart
@@ -37,7 +37,7 @@ class OnboardingViewBottomSheet extends StatelessWidget {
           CustomWideButton(
             buttonText: AppStrings.getStarted.translate,
             onPressed: () {
-              context.pushReplacement(Routes.signUpRoute);
+              context.pushReplacement(Routes.loginRoute);
             },
           ),
         ],


### PR DESCRIPTION
- Refactor authentication error messages to use a more generic "invalidCredentials" message.
- Add new translation strings for "invalidCredentials" and "LoginTo" in both Arabic and English.
- Update dependency injection to include FirebaseAuth and FirebaseFirestore for authentication.
- Implement AuthCubit for handling authentication logic, including setting the user ID in shared preferences upon successful login or registration.
- Add AuthListenerWidget to handle authentication state changes and display appropriate messages.
- Create LoginView and related widgets for the login screen.
- Update SignupView to use AuthCubit for registration and handle navigation to the home route upon successful registration.
- Add CustomSnackBar widget for displaying success and error messages.
- Update route management to include a login route and initialize AuthCubit when navigating to authentication screens.
- Update OnboardingViewBottomSheet to navigate to the login route instead of the sign-up route.